### PR TITLE
fix Codex session detection and add 90% warning thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to WAT321 Willy's AI Tools will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2026-04-10
+
+### Changed
+- Warning color threshold standardized at 90% across all six widgets
+
+### Fixed
+- Codex session tokens not detecting active sessions (readHead buffer too small for large session_meta)
+
 ## [1.0.3] - 2026-04-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wat321",
   "displayName": "WAT321 Willy's AI Tools",
   "description": "Real-time Claude & Codex status bar widgets: session usage, weekly limits, and more",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publisher": "WillyDrucker",
   "repository": {
     "type": "git",

--- a/src/WAT321_CLAUDE_USAGE_5H/widget.ts
+++ b/src/WAT321_CLAUDE_USAGE_5H/widget.ts
@@ -85,7 +85,10 @@ export class ClaudeUsage5hrWidget implements StatusBarWidget {
           this.item.text = `Claude (5hr) ${makeBar(pct)} ${pct}%`;
         }
         this.item.tooltip = buildTooltip(state.data);
-        this.item.color = undefined;
+        this.item.color =
+          pct >= 90
+            ? new vscode.ThemeColor("statusBarItem.warningForeground")
+            : undefined;
         this.item.show();
         break;
       }

--- a/src/WAT321_CLAUDE_USAGE_WEEKLY/widget.ts
+++ b/src/WAT321_CLAUDE_USAGE_WEEKLY/widget.ts
@@ -50,7 +50,10 @@ export class ClaudeUsageWeeklyWidget implements StatusBarWidget {
           this.item.text = `Claude weekly ${makeBar(pct)} ${pct}%`;
         }
         this.item.tooltip = buildTooltip(state.data);
-        this.item.color = undefined;
+        this.item.color =
+          pct >= 90
+            ? new vscode.ThemeColor("statusBarItem.warningForeground")
+            : undefined;
         this.item.show();
         break;
       }

--- a/src/WAT321_CODEX_SESSION_TOKENS/service.ts
+++ b/src/WAT321_CODEX_SESSION_TOKENS/service.ts
@@ -115,7 +115,7 @@ export class CodexSessionTokenService {
     // Get session title - prefer session_index, fall back to first user message
     let sessionTitle = this.getSessionTitle(codexDir, this.cachedRolloutPath);
     if (!sessionTitle) {
-      const head = readHead(this.cachedRolloutPath);
+      const head = readHead(this.cachedRolloutPath, 32_768);
       if (head) {
         sessionTitle = this.parseFirstUserMessage(head);
       }
@@ -231,7 +231,8 @@ export class CodexSessionTokenService {
 
   /** Read cwd from session_meta (first line of rollout) */
   private parseCwd(rolloutPath: string): string | null {
-    const head = readHead(rolloutPath);
+    // Codex session_meta includes full system prompt and can exceed 16KB
+    const head = readHead(rolloutPath, 32_768);
     if (!head) return null;
 
     const firstLine = head.split("\n")[0];

--- a/src/WAT321_CODEX_SESSION_TOKENS/widget.ts
+++ b/src/WAT321_CODEX_SESSION_TOKENS/widget.ts
@@ -42,17 +42,10 @@ export class CodexSessionTokensWidget implements vscode.Disposable {
           this.item.text = `🗜️ Codex ${formatTokens(session.contextUsed)} / ${formatTokens(session.contextWindowSize)} ${formatPct(usedPct)}`;
         }
 
-        if (usedPct >= 100) {
-          this.item.color = new vscode.ThemeColor(
-            "statusBarItem.errorForeground"
-          );
-        } else if (usedPct >= 85) {
-          this.item.color = new vscode.ThemeColor(
-            "statusBarItem.warningForeground"
-          );
-        } else {
-          this.item.color = undefined;
-        }
+        this.item.color =
+          usedPct >= 90
+            ? new vscode.ThemeColor("statusBarItem.warningForeground")
+            : undefined;
 
         this.item.tooltip = this.buildTooltip(session);
         this.item.show();

--- a/src/WAT321_CODEX_USAGE_5H/widget.ts
+++ b/src/WAT321_CODEX_USAGE_5H/widget.ts
@@ -82,7 +82,10 @@ export class CodexUsage5hrWidget implements StatusBarWidget {
           this.item.text = `Codex (5 hour) ${makeBar(usedPct)} ${remainingPct}%`;
         }
         this.item.tooltip = buildTooltip(state.data);
-        this.item.color = undefined;
+        this.item.color =
+          remainingPct <= 10
+            ? new vscode.ThemeColor("statusBarItem.warningForeground")
+            : undefined;
         this.item.show();
         break;
       }

--- a/src/WAT321_CODEX_USAGE_WEEKLY/widget.ts
+++ b/src/WAT321_CODEX_USAGE_WEEKLY/widget.ts
@@ -52,7 +52,10 @@ export class CodexUsageWeeklyWidget implements StatusBarWidget {
           this.item.text = `Codex weekly ${makeBar(usedPct)} ${remainingPct}%`;
         }
         this.item.tooltip = buildTooltip(state.data);
-        this.item.color = undefined;
+        this.item.color =
+          remainingPct <= 10
+            ? new vscode.ThemeColor("statusBarItem.warningForeground")
+            : undefined;
         this.item.show();
         break;
       }

--- a/src/claude-session-tokens/widgets/tokenWidget.ts
+++ b/src/claude-session-tokens/widgets/tokenWidget.ts
@@ -46,17 +46,10 @@ export class ClaudeSessionTokensWidget implements StatusBarWidget {
           this.item.text = `🗜️ Claude ${formatTokens(session.contextUsed)} / ${formatTokens(ceilingTokens)} ${formatPct(pctOfCeiling)}`;
         }
 
-        if (pctOfCeiling >= 100) {
-          this.item.color = new vscode.ThemeColor(
-            "statusBarItem.errorForeground"
-          );
-        } else if (pctOfCeiling >= 85) {
-          this.item.color = new vscode.ThemeColor(
-            "statusBarItem.warningForeground"
-          );
-        } else {
-          this.item.color = undefined;
-        }
+        this.item.color =
+          pctOfCeiling >= 90
+            ? new vscode.ThemeColor("statusBarItem.warningForeground")
+            : undefined;
 
         this.item.tooltip = this.buildTooltip(session);
         this.item.show();


### PR DESCRIPTION
## Summary
- Fix Codex session tokens not detecting active sessions (readHead buffer too small)
- Add warning color at 90% threshold for all six widgets

## Test plan
- [x] Verified readHead fix with 15KB session_meta line
- [x] All 15 pre-publish checks passed
- [x] Clean build with lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)