### PR TITLE
WAT321 v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to WAT321 Willy's AI Tools will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7] - 2026-04-11
+
+### Added
+- Auto-compact threshold setting (`wat321.autoCompactThreshold`) - override the session token ceiling display (0 = auto, 1-100 = custom percentage)
+- Reset WAT321 checkbox in settings page with confirmation dialog
+- Additional Settings and Reset WAT321 sections in README
+- Customize Visible Widgets section in README
+
+### Changed
+- Session token progress bars changed from blue to yellow for visual distinction from usage widgets
+- Startup offline fix - first transient API error absorbed during loading state, prevents false "Offline" flash
+- README updated with Not Connected wording for API-only accounts
+- Clear settings now also resets autoCompactThreshold
+- Rebroadcast invalidates cached autoCompactPct so threshold changes apply immediately
+
 ## [1.0.6] - 2026-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ All six tools install together, but Codex is **disabled by default**. To enable:
 
 <img src="images/screenshots/CODEX_WAT321_SETTINGS.png" width="350">
 
-Once enabled, you can toggle individual Codex widgets on or off using the **status bar overflow button** (`>>` at the bottom-left):
+## Customize Visible Widgets
+
+You can show or hide individual widgets by right-clicking the status bar or using the overflow menu (`>>`):
 
 ![Status bar button](images/screenshots/STATUS_BAR_BUTTON.png)
 
@@ -124,13 +126,22 @@ Once enabled, you can toggle individual Codex widgets on or off using the **stat
 | Claude | Team / Enterprise | Unknown - untested with the usage API |
 | Codex | Plus / Pro / Team | Supported |
 
-API-only Anthropic accounts without CLI OAuth credentials will see the Claude widgets hidden, which is expected.
+API-only Anthropic accounts without CLI OAuth credentials will see Claude widgets showing "Not Connected", which is expected. They will activate automatically if CLI credentials are set up later.
 
 ## Rate Limits
 
 Both Claude and Codex usage APIs have rate limits. WAT321 polls conservatively to stay well within safe thresholds. However, **repeatedly reinstalling or reloading the extension in quick succession can trigger a temporary rate-limit lockout**.
 
 If a lockout occurs, the status bar will show "Offline" and the tooltip will display a countdown timer. The extension will automatically reconnect when the lockout expires - no action needed.
+
+## Additional Settings
+
+- **Auto-Compact Threshold** - Override the percentage ceiling shown in the Claude session token widget. Set to 0 (default) to use Claude's own setting, or enter a value like 85 for 85%.
+- **Status Bar Priority** - Adjust widget ordering if they overlap with other extensions.
+
+## Reset WAT321
+
+To start fresh, open the command palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and run **WAT321: Clear All Settings**, or check the **Reset WAT321** checkbox at the bottom of the WAT321 settings page. This resets all settings to defaults and removes stored data.
 
 ## Issues & Feedback
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wat321",
   "displayName": "WAT321 Willy's AI Tools",
   "description": "Real-time Claude & Codex status bar widgets: session usage, weekly limits, and more",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "publisher": "WillyDrucker",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,20 @@
           "default": 1001,
           "order": 4,
           "markdownDescription": "Base priority for WAT321 status bar items. Higher values appear further left. Adjust if widgets overlap with other extensions. *Requires window reload.*"
+        },
+        "wat321.autoCompactThreshold": {
+          "type": "number",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 100,
+          "order": 5,
+          "markdownDescription": "Override the auto-compact ceiling percentage shown in the Claude session token widget. Set to `0` to read from Claude's own settings (default). Values `1`-`100` set a custom display threshold (e.g. `85` = 85%)."
+        },
+        "wat321.clearAllData": {
+          "type": "boolean",
+          "default": false,
+          "order": 99,
+          "markdownDescription": "**Reset WAT321** - Check this box to clear all WAT321 settings and stored data. This will reset all options above to defaults and remove cooldown timestamps and welcome flags from `~/.wat321/`. A confirmation dialog will appear before any changes are made."
         }
       }
     }

--- a/src/WAT321_CLAUDE_SESSION_TOKENS/service.ts
+++ b/src/WAT321_CLAUDE_SESSION_TOKENS/service.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync, existsSync, statSync } from "fs";
 import { homedir } from "os";
 import { join, basename } from "path";
+import * as vscode from "vscode";
 import type { SessionEntry, WidgetState } from "./types";
 import { readTail, readHead } from "../shared/fs/fileReaders";
 import { normalizePath, getProjectKey } from "../shared/fs/pathUtils";
@@ -57,6 +58,9 @@ export class ClaudeSessionTokenService {
   }
 
   rebroadcast(): void {
+    // Invalidate cached values so next poll picks up setting changes
+    this.cachedAutoCompactPct = null;
+    this.lastFileSize = 0;
     for (const fn of this.listeners) fn(this.state);
   }
 
@@ -359,6 +363,13 @@ export class ClaudeSessionTokenService {
   }
 
   private readAutoCompactPct(home: string): number {
+    // Check WAT321 setting first
+    const watOverride = vscode.workspace
+      .getConfiguration("wat321")
+      .get<number>("autoCompactThreshold", 0);
+    if (watOverride >= 1 && watOverride <= 100) return watOverride;
+
+    // Fall back to Claude's own setting
     try {
       const settingsPath = join(home, ".claude", "settings.json");
       const settings = JSON.parse(readFileSync(settingsPath, "utf8"));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,8 +110,11 @@ export function activate(context: vscode.ExtensionContext) {
         }
       }
 
-      // Re-render all widgets immediately when displayMode changes
-      if (e.affectsConfiguration("wat321.displayMode")) {
+      // Re-render all widgets immediately when display settings change
+      if (
+        e.affectsConfiguration("wat321.displayMode") ||
+        e.affectsConfiguration("wat321.autoCompactThreshold")
+      ) {
         claudeGroup?.usageService.rebroadcast();
         codexGroup?.usageService.rebroadcast();
         claudeGroup?.tokenService.rebroadcast();

--- a/src/shared/claude-usage/service.ts
+++ b/src/shared/claude-usage/service.ts
@@ -207,11 +207,13 @@ export class ClaudeUsageSharedService {
       return;
     }
 
-    // Track consecutive non-429 errors. If we have good data and this is
-    // the first failure (transient after alt-tab, idle, etc.), silently
-    // keep showing cached data and retry on the next poll cycle.
+    // Absorb first transient error silently. On startup (loading state),
+    // this prevents flashing "Offline" before the network is ready.
+    // When we have good data, this preserves cached values on transient failures.
     this.consecutiveErrors++;
-    if (this.state.status === "ok" && this.consecutiveErrors < 2) return;
+    if (this.consecutiveErrors < 2) {
+      if (this.state.status === "ok" || this.state.status === "loading") return;
+    }
 
     if (statusCode && AUTH_ERROR_CODES.has(statusCode)) {
       this.setState({

--- a/src/shared/clearSettings.ts
+++ b/src/shared/clearSettings.ts
@@ -5,38 +5,61 @@ import { join } from "path";
 
 const STAMP_DIR = join(homedir(), ".wat321");
 
+async function performClear(): Promise<void> {
+  const confirm = await vscode.window.showWarningMessage(
+    "This will reset all WAT321 settings to defaults and clear stored data. Continue?",
+    "Clear Everything",
+    "Cancel"
+  );
+
+  if (confirm !== "Clear Everything") {
+    // User cancelled - reset the checkbox back to false
+    await vscode.workspace
+      .getConfiguration("wat321")
+      .update("clearAllData", false, vscode.ConfigurationTarget.Global);
+    return;
+  }
+
+  // Reset all settings to defaults
+  const config = vscode.workspace.getConfiguration("wat321");
+  await config.update("enableClaude", undefined, vscode.ConfigurationTarget.Global);
+  await config.update("enableCodex", undefined, vscode.ConfigurationTarget.Global);
+  await config.update("displayMode", undefined, vscode.ConfigurationTarget.Global);
+  await config.update("statusBarPriority", undefined, vscode.ConfigurationTarget.Global);
+  await config.update("autoCompactThreshold", undefined, vscode.ConfigurationTarget.Global);
+  await config.update("clearAllData", false, vscode.ConfigurationTarget.Global);
+
+  // Remove ~/.wat321/ folder
+  try {
+    if (existsSync(STAMP_DIR)) {
+      rmSync(STAMP_DIR, { recursive: true, force: true });
+    }
+  } catch {
+    // best-effort
+  }
+
+  vscode.window.showInformationMessage(
+    "WAT321 settings cleared. All defaults restored."
+  );
+}
+
 export function registerClearSettingsCommand(
   context: vscode.ExtensionContext
 ): void {
+  // Command palette entry
   context.subscriptions.push(
-    vscode.commands.registerCommand("wat321.clearAllSettings", async () => {
-      const confirm = await vscode.window.showWarningMessage(
-        "This will reset all WAT321 settings to defaults and clear stored data. Continue?",
-        "Clear Everything",
-        "Cancel"
-      );
+    vscode.commands.registerCommand("wat321.clearAllSettings", performClear)
+  );
 
-      if (confirm !== "Clear Everything") return;
-
-      // Reset all settings to defaults
-      const config = vscode.workspace.getConfiguration("wat321");
-      await config.update("enableClaude", undefined, vscode.ConfigurationTarget.Global);
-      await config.update("enableCodex", undefined, vscode.ConfigurationTarget.Global);
-      await config.update("displayMode", undefined, vscode.ConfigurationTarget.Global);
-      await config.update("statusBarPriority", undefined, vscode.ConfigurationTarget.Global);
-
-      // Remove ~/.wat321/ folder
-      try {
-        if (existsSync(STAMP_DIR)) {
-          rmSync(STAMP_DIR, { recursive: true, force: true });
-        }
-      } catch {
-        // best-effort
+  // Settings page checkbox trigger
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("wat321.clearAllData")) {
+        const checked = vscode.workspace
+          .getConfiguration("wat321")
+          .get<boolean>("clearAllData", false);
+        if (checked) performClear();
       }
-
-      vscode.window.showInformationMessage(
-        "WAT321 settings cleared. All defaults restored."
-      );
     })
   );
 }

--- a/src/shared/codex-usage/service.ts
+++ b/src/shared/codex-usage/service.ts
@@ -226,11 +226,13 @@ export class CodexUsageSharedService {
       return;
     }
 
-    // Track consecutive non-429 errors. If we have good data and this is
-    // the first failure (transient after alt-tab, idle, etc.), silently
-    // keep showing cached data and retry on the next poll cycle.
+    // Absorb first transient error silently. On startup (loading state),
+    // this prevents flashing "Offline" before the network is ready.
+    // When we have good data, this preserves cached values on transient failures.
     this.consecutiveErrors++;
-    if (this.state.status === "ok" && this.consecutiveErrors < 2) return;
+    if (this.consecutiveErrors < 2) {
+      if (this.state.status === "ok" || this.state.status === "loading") return;
+    }
 
     if (statusCode && AUTH_ERROR_CODES.has(statusCode)) {
       this.setState({

--- a/src/shared/ui/tokenFormatters.ts
+++ b/src/shared/ui/tokenFormatters.ts
@@ -1,4 +1,4 @@
-const FILLED = "\uD83D\uDFE6"; // Blue square
+const FILLED = "\uD83D\uDFE8"; // Yellow square
 const EMPTY = "\u2B1B"; // Black square
 const BAR_WIDTH = 10;
 
@@ -20,7 +20,7 @@ export function formatPct(pct: number): string {
   return `${Math.round(pct)}%`;
 }
 
-/** Blue/black block bar for token context display */
+/** Yellow/black block bar for session token context display */
 export function makeTokenBar(pct: number, width: number = BAR_WIDTH): string {
   const clamped = Math.max(0, Math.min(100, pct));
   const filled = Math.round((clamped / 100) * width);


### PR DESCRIPTION
## Summary
- Yellow session token bars for visual distinction from usage widgets
- Auto-compact threshold setting for custom ceiling display
- Reset WAT321 checkbox in settings page with confirmation dialog
- Startup offline fix - absorb first transient error during loading
- README updated with new settings, reset section, widget customization

## Test plan
- [x] Build passes (clean -> lint -> tsc)
- [x] All pre-publish checks pass
- [x] .vsix packages cleanly (53 files, 729KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)