### PR TITLE
Notify only after user-facing Codex turns complete

### DIFF
--- a/src/WAT321_CODEX_SESSION_TOKENS/activeRolloutStore.ts
+++ b/src/WAT321_CODEX_SESSION_TOKENS/activeRolloutStore.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { writeFileAtomic } from "../shared/fs/atomicWrite";
 import { normalizePath } from "../shared/fs/pathUtils";
 import { clientStateDir } from "../shared/wat321Paths";
-import { parseCwd } from "./parsers";
+import { parseSessionMeta } from "./parsers";
 
 /**
  * Persisted pointer to the Codex rollout this workspace was last
@@ -47,8 +47,9 @@ export function readPersistedRollout(workspacePath: string): string | null {
     const raw = readFileSync(storePath(), "utf8");
     const path = (JSON.parse(raw) as { rolloutPath?: unknown }).rolloutPath;
     if (typeof path !== "string" || !existsSync(path)) return null;
-    const cwd = parseCwd(path);
-    if (!cwd || !matchesWorkspace(workspacePath, cwd)) return null;
+    const meta = parseSessionMeta(path);
+    if (!meta || meta.isSubagent) return null;
+    if (!matchesWorkspace(workspacePath, meta.cwd)) return null;
     return path;
   } catch {
     return null;

--- a/src/WAT321_CODEX_SESSION_TOKENS/parsers.ts
+++ b/src/WAT321_CODEX_SESSION_TOKENS/parsers.ts
@@ -20,6 +20,11 @@ export interface LastTokenCount {
 
 const DEFAULT_CODEX_CONTEXT_WINDOW = 258_400;
 
+export interface CodexSessionMeta {
+  cwd: string;
+  isSubagent: boolean;
+}
+
 /** Scan the tail (up to the last 200 lines) for the most recent
  * `token_count` event. Returns `last_token_usage.total_tokens` (with
  * a fallback to `input_tokens` for older rollout formats) and the
@@ -74,25 +79,41 @@ export function parseLastTokenCount(tail: string): LastTokenCount | null {
   return null;
 }
 
-/** Read `session_meta.payload.cwd` from the first line of the rollout.
- * Used both to match rollouts to a workspace and to label the widget.
+/** Read the fields needed to decide whether a rollout is a user-facing
+ * workspace session from its first `session_meta` line.
  * `readFirstLine` reads in chunks until a newline, so an oversized
  * session_meta first line (routinely 15-25KB on recent Codex CLI
  * rollouts - can grow further as Codex adds metadata) is always
  * captured intact. */
-export function parseCwd(rolloutPath: string): string | null {
+export function parseSessionMeta(
+  rolloutPath: string
+): CodexSessionMeta | null {
   const firstLine = readFirstLine(rolloutPath);
   if (!firstLine) return null;
 
   try {
     const entry = JSON.parse(firstLine);
     if (entry.type === "session_meta") {
-      return (entry.payload?.cwd as string) || null;
+      const cwd = entry.payload?.cwd;
+      if (typeof cwd !== "string" || cwd.length === 0) return null;
+      const source = entry.payload?.source;
+      const isSubagent =
+        typeof source === "object" &&
+        source !== null &&
+        Object.prototype.hasOwnProperty.call(source, "subagent");
+      return { cwd, isSubagent };
     }
   } catch {
     // ignore
   }
   return null;
+}
+
+/** Read `session_meta.payload.cwd` from the first line of the rollout.
+ * Used to label the active widget after discovery has already rejected
+ * internal Codex subagent rollouts. */
+export function parseCwd(rolloutPath: string): string | null {
+  return parseSessionMeta(rolloutPath)?.cwd ?? null;
 }
 
 /** Scan the header for the initial model slug. Checks `turn_context`

--- a/src/WAT321_CODEX_SESSION_TOKENS/rolloutDiscovery.ts
+++ b/src/WAT321_CODEX_SESSION_TOKENS/rolloutDiscovery.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import type { CodexSessionIndex } from "./types";
 import { readTail } from "../shared/fs/fileReaders";
 import { normalizePath } from "../shared/fs/pathUtils";
-import { parseCwd } from "./parsers";
+import { parseSessionMeta } from "./parsers";
 import { classifyCodexTurn } from "./turnClassifier";
 
 /**
@@ -130,8 +130,9 @@ function buildCandidate(
     return null;
   }
 
-  const cwd = parseCwd(fullPath);
-  if (!cwd) return null;
+  const meta = parseSessionMeta(fullPath);
+  if (!meta || meta.isSubagent) return null;
+  const { cwd } = meta;
   const cwdNorm = normalizePath(cwd);
   // Bidirectional match, symmetric with Claude's walkWorkspaceSessions:
   // also matches a native session launched from a subfolder of the open

--- a/src/WAT321_CODEX_SESSION_TOKENS/service.ts
+++ b/src/WAT321_CODEX_SESSION_TOKENS/service.ts
@@ -208,7 +208,7 @@ export class CodexSessionTokenService extends SessionTokenServiceBase<CodexToken
         this.workspacePath,
         this.cachedRolloutPath
       );
-      if (result.path) this.cachedRolloutPath = result.path;
+      this.cachedRolloutPath = result.path;
       this.cachedInventory = { total: result.total, inProgress: result.inProgress };
       this.lastRolloutScan = now;
       this.nonActiveTracker.observe(result.candidates, result.path, now);

--- a/src/WAT321_CODEX_SESSION_TOKENS/turnClassifier.ts
+++ b/src/WAT321_CODEX_SESSION_TOKENS/turnClassifier.ts
@@ -4,7 +4,7 @@ import type { LastEntryKind } from "../shared/turnState";
  * Turn-state classification for Codex rollout tails - the single home
  * for "what is the last turn doing". Two consumers with deliberately
  * different biases: classifyCodexTurn (idle bias, drives the active
- * indicator) and isCodexTurnComplete (fire bias, drives the
+ * indicator) and isCodexTurnComplete (terminal-only bias, drives the
  * notification gate).
  */
 
@@ -12,9 +12,8 @@ import type { LastEntryKind } from "../shared/turnState";
  * one of the turn states used by the session token active indicator.
  * Walks backwards, skips bookkeeping events, returns the first
  * definitive event found:
- *   - `assistant-done` - a completed assistant response OR a turn
- *     ended normally by `task_complete`. Resolves the indicator
- *     instantly and is notification-eligible.
+ *   - `assistant-done` - a turn ended normally by `task_complete`.
+ *     Resolves the indicator instantly and is notification-eligible.
  *   - `interrupted` - a turn ended by `turn_aborted`, which Codex
  *     writes on user interrupt (Esc / Ctrl+C). Resolves the indicator
  *     to idle like done, but the notification gate suppresses it so a
@@ -23,9 +22,9 @@ import type { LastEntryKind } from "../shared/turnState";
  *   - `user` - last event was a user message (user is waiting)
  *   - `unknown` - no definitive event in the tail window
  *
- * Unlike `isCodexTurnComplete` (which biases toward true for
- * notification firing), this biases `unknown` to idle so the thinking
- * indicator does not pin itself on when we cannot tell. */
+ * Unlike `isCodexTurnComplete` (which requires an explicit terminal
+ * marker), this biases `unknown` to idle so the thinking indicator
+ * does not pin itself on when we cannot tell. */
 export function classifyCodexTurn(tail: string): LastEntryKind {
   const lines = tail.trimEnd().split("\n");
   for (let i = lines.length - 1; i >= 0; i--) {
@@ -54,21 +53,19 @@ export function classifyCodexTurn(tail: string): LastEntryKind {
     if (entry.type === "event_msg" && ptype === "turn_aborted") {
       return "interrupted";
     }
+    // Current-turn boundary. Reaching task_started while walking
+    // backwards proves there is no terminal marker in this turn.
+    // Stop here so an unrecognized event cannot fall through into
+    // the previous turn's task_complete and create a false toast.
+    if (entry.type === "event_msg" && ptype === "task_started") {
+      return "assistant-pending";
+    }
 
-    // Assistant-response events = done ONLY for the final_answer phase.
-    // Codex emits an `agent_message` with phase=commentary mid-turn
-    // ("I'll look into X first") before the phase=final_answer message
-    // at turn end. Treating commentary as turn-complete would flicker
-    // the thinking indicator idle between commentary and the next
-    // reasoning/tool event, so only final_answer (plus the explicit
-    // turn_aborted / task_complete signals) closes the turn. Commentary
-    // falls through to keep scanning so a later definitive signal
-    // (function_call, reasoning) wins.
+    // Assistant-response events are item-level progress, not turn
+    // completion. Codex emits an agent_message with phase=commentary
+    // mid-turn and phase=final_answer near the end, but more lifecycle
+    // work can still follow until task_complete is persisted.
     if (entry.type === "event_msg" && ptype === "agent_message") {
-      const phase = payload?.phase;
-      if (phase === "final_answer") return "assistant-done";
-      // phase=commentary or unphased: the assistant is mid-turn (more
-      // follows the commentary), so report pending.
       return "assistant-pending";
     }
     // `response_item/message` role=assistant has no phase tag and fires
@@ -78,7 +75,7 @@ export function classifyCodexTurn(tail: string): LastEntryKind {
     if (entry.type === "response_item" && ptype === "message" && payload?.role === "assistant") {
       return "assistant-pending";
     }
-    if (entry.type === "response.output_text.done") return "assistant-done";
+    if (entry.type === "response.output_text.done") return "assistant-pending";
     if (entry.type === "message" && payload?.role === "assistant") return "assistant-pending";
 
     // User messages = user is waiting for a response
@@ -112,14 +109,11 @@ export function classifyCodexTurn(tail: string): LastEntryKind {
  * tail represents a completed assistant turn. Thin wrapper over
  * `classifyCodexTurn` so the detection rules stay in one place.
  *
- * `user` and `assistant-pending` = mid-turn, notification gate should
- * suppress. `assistant-done` and `unknown` = complete, notification
- * gate should fire. The `unknown` -> fire bias is intentional: a
- * missing definitive event must not silently lose a notification.
- * Interrupts (`turn_aborted`) map to `interrupted` via the classifier
- * - neither `assistant-done` nor `unknown` - so the gate correctly
- * suppresses notifications on cancelled turns. */
+ * Only `assistant-done` is notification-eligible. Unknown or malformed
+ * activity fails closed because a missed notification is preferable
+ * to interrupting the user during an active turn. Interrupts
+ * (`turn_aborted`) map to `interrupted` and remain suppressed. */
 export function isCodexTurnComplete(tail: string): boolean {
   const state = classifyCodexTurn(tail);
-  return state === "assistant-done" || state === "unknown";
+  return state === "assistant-done";
 }


### PR DESCRIPTION
## Summary

The original Codex notification behavior could send multiple notifications during a single turn because internal subagent completions were treated as completed activity before the full user-facing turn had finished.

This change:

- requires an explicit `task_complete` event before a Codex turn is eligible for notification
- treats response text and commentary as activity within an ongoing turn
- excludes internal subagent rollouts from Codex session selection and completion tracking

## Testing

- ESLint
- TypeScript compilation
- Focused regression checks with 8 assertions
- Manual runtime verification that a subagent completion produces no notification while the completed parent turn produces exactly one